### PR TITLE
Hi tsurdilo 

### DIFF
--- a/src/main/java/com/intalio/web/profile/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/intalio/web/profile/impl/ProfileServiceImpl.java
@@ -56,6 +56,7 @@ public class ProfileServiceImpl implements IDiagramProfileService {
     public void init(ServletContext context) {
         _registry.put("default", new DefaultProfileImpl(context));
         _registry.put("jbpm", new JbpmProfileImpl(context));
+        _registry.put("drools", new JbpmProfileImpl(context));
         _registry.put("epn", new EpnProfileImpl(context));
         
     }


### PR DESCRIPTION
Make "drools" a supported profile name. Guvnor invokes the editor with the profile "drools" which leads to the following exception:

java.lang.IllegalArgumentException: No profile with the name drools was registered
    org.oryxeditor.server.EditorHandler.doGet(EditorHandler.java:286)
    javax.servlet.http.HttpServlet.service(HttpServlet.java:617)
    javax.servlet.http.HttpServlet.service(HttpServlet.java:717)
    com.intalio.web.filter.impl.PluggableFilter.doFilter(PluggableFilter.java:75)
    org.jboss.web.tomcat.filters.ReplyHeaderFilter.doFilter(ReplyHeaderFilter.java:96)
