### PR TITLE
Updating dependendy to org.eclipse.bpmn2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.eclipse</groupId>
       <artifactId>org.eclipse.bpmn2</artifactId>
-      <version>0.7.0.000-JBOSS-SNAPSHOT</version>
+      <version>0.7.0.003</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>


### PR DESCRIPTION
Hi tsurdilo

I've found the missing jar, thanks. This commit fixes the dependency in the maven pom.xml.

Karl
